### PR TITLE
Docker script updated to Docker recommended pattern

### DIFF
--- a/linux/apt-based/5-docker.sh
+++ b/linux/apt-based/5-docker.sh
@@ -1,9 +1,25 @@
 #!/usr/bin/env bash
 # 5-docker.sh
 
-sudo snap install --classic docker
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo $(lsb_release -cs)) stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install -y \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+
 sudo addgroup --system docker
 sudo adduser $USER docker
 newgrp docker
-sudo snap disable docker
-sudo snap enable docker


### PR DESCRIPTION
Docker Script updated to Docker recommended pattern

Instead of using snap (out of date), now adding Docker managed apt repository to apt and installing through apt.

Resolves #6 