### PR TITLE
updated apt to scriptable apt binaries

### DIFF
--- a/linux/apt-based/1-package-managers.sh
+++ b/linux/apt-based/1-package-managers.sh
@@ -3,17 +3,17 @@
 set -x
 COMMON_PROFILE=.vprofile
 
-sudo apt update
-sudo apt upgrade -y
+sudo apt-get update
+sudo apt-get upgrade -y
 
 [ $(which flatpak) ] || echo "*** flatpak will now be installed; restart required ***"
 
-sudo apt install -y flatpak
+sudo apt-get install -y flatpak
 flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-sudo apt install -y snapd
+sudo apt-get install -y snapd
 
-sudo apt autoremove && sudo apt clean
+sudo apt-get autoremove && sudo apt-get clean
 
 sudo flatpak update
 sudo snap refresh 

--- a/linux/apt-based/3-apps.sh
+++ b/linux/apt-based/3-apps.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 # 3-apps.sh
 
+# prefer apt wherever practical
+
 COMMON_PROFILE=.vprofile
 
 brew update
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-sudo apt install -y jq
+sudo apt-get install -y jq
 sudo snap install yq
-sudo apt install -y wget
-sudo apt install -y procps
-sudo apt install -y bat
+sudo apt-get install -y wget
+sudo apt-get install -y procps
+sudo apt-get install -y bat
 brew install tlrc
 
 sudo snap install --classic aws-cli
@@ -21,13 +23,14 @@ brew install stern
 
 # sudo snap install --classic android-studio
 sudo snap install --classic codium
-sudo apt install -y meld
+sudo apt-get install -y meld
 
 brew install tig gitui
-sudo apt install -y git-cola
-sudo apt install -y kitty
+sudo apt-get install -y git-cola
+sudo apt-get install -y kitty
+sudo apt-get install -y xclip
 
-curl -f https://zed.dev/install.sh | sh
+type zed > /dev/null || curl -f https://zed.dev/install.sh | sh
 
 ### app configurations ###
 
@@ -40,6 +43,14 @@ if [ -z "$entry" ]; then
 code() {
     codium \$@
 }   
+EOF
+fi
+
+entry=$(cat $HOME/$COMMON_PROFILE | grep 'alias xc')
+if [ -z "$entry" ]; then
+    cat <<EOF >> $HOME/$COMMON_PROFILE
+
+alias xc='xclip -selection clipboard'
 EOF
 fi
 

--- a/linux/apt-based/4-languages.sh
+++ b/linux/apt-based/4-languages.sh
@@ -3,9 +3,9 @@
 
 # python
 sudo add-apt-repository -y ppa:deadsnakes/ppa
-sudo apt update
+sudo apt-get update
 latest_stable_python=$(curl https://endoflife.date/api/python.json | jq -r '.[0].cycle')
-sudo apt install -y python${latest_stable_python}
+sudo apt-get install -y python${latest_stable_python}
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
 [ $(which python) ] || sudo ln -s $(which python3) $HOME/.local/bin/python
 


### PR DESCRIPTION
Resolves #8 

See issue #8 for background

Changes:
- updated `apt` to `apt-get` in package-managers setup
- updated `apt` to `apt-get` in apps setup
- updated `apt` to `apt-get` in languages setup
- installs xclip
- zed install only triggers if zed not present

