### PR TITLE
fix: use set -x instead of echo for language version readout

### DIFF
--- a/linux/apt-based/4-languages.sh
+++ b/linux/apt-based/4-languages.sh
@@ -34,17 +34,12 @@ sudo snap install zig --classic --beta
 source $HOME/.bashrc
 
 echo
-echo "python --version" && \
-      python --version && echo
-echo "nvm --version" && \
-      nvm --version && echo
-echo "node -v" && \
-      node -v && echo
-echo "go version" && \
-      go version && echo
-echo "rustup -V" && \
-      rustup -V && echo
-echo "cargo -V" && \
-      cargo -V && echo
-echo "zig version" && \
-      zig version && echo
+echo "nvm --version"
+nvm --version
+set -x
+node -v
+python --version
+go version
+rustup -V
+cargo -V
+zig version


### PR DESCRIPTION
# Description

use set -x instead of echo for language version readout

Resolves #10 

Note that change is not applied to nvm version since nvm is a script that is bad for the readability.

# Changes

- sets x flag ahead of language version readout (except for nvm)
- removes echo commands for version readouts (except for nvm)
- keeps echo for nvm since nvm is a script