### PR TITLE
feature: remove LibreOffice

### DIFF
--- a/linux/apt-based/3-apps.sh
+++ b/linux/apt-based/3-apps.sh
@@ -59,3 +59,5 @@ mkdir -p "${kitty_conf_dir}"
 touch "${kitty_conf}"
 grep -q "new_tab_with_cwd" "${kitty_conf}" || \
   echo "map alt+t new_tab_with_cwd" >> "${kitty_conf}"
+
+sudo apt remove --purge libreoffice-\*


### PR DESCRIPTION
Removes LibreOffice which is installed by default during OS installation.

Resolves #19 